### PR TITLE
Add support for comments other than comment.line

### DIFF
--- a/themes/pycharm-dark-color-theme.json
+++ b/themes/pycharm-dark-color-theme.json
@@ -174,7 +174,7 @@
 			}
 		},
 		{
-			"scope": ["comment.line", "punctuation.definition.comment.python"],
+			"scope": ["comment", "punctuation.definition.comment.python"],
 			"settings": {
 				"foreground": "#808080"
 			}

--- a/themes/pycharm-darkplus-color-theme.json
+++ b/themes/pycharm-darkplus-color-theme.json
@@ -37,7 +37,7 @@
 			}
 		},
 		{
-			"scope": ["comment.line", "punctuation.definition.comment.python"],
+			"scope": ["comment", "punctuation.definition.comment.python"],
 			"settings": {
 				"foreground": "#808080"
 			}

--- a/themes/pycharm-night-color-theme.json
+++ b/themes/pycharm-night-color-theme.json
@@ -104,7 +104,7 @@
 			}
 		},
 		{
-			"scope": ["comment.line", "punctuation.definition.comment.python"],
+			"scope": ["comment", "punctuation.definition.comment.python"],
 			"settings": {
 				"foreground": "#808080"
 			}

--- a/themes/pycharm-original-color-theme.json
+++ b/themes/pycharm-original-color-theme.json
@@ -95,7 +95,7 @@
 			}
 		},
 		{
-			"scope": ["comment.line", "punctuation.definition.comment.python"],
+			"scope": ["comment", "punctuation.definition.comment.python"],
 			"settings": {
 				"foreground": "#808080"
 			}


### PR DESCRIPTION
This should fix #5 

Add support for other types of comment, eg block comments in languages other than Python.